### PR TITLE
Improve neural compression precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2025-08-17
+- Improved neural compression precision with deterministic padding and 16-bit quantization
 - Added neural compression module and CLI integration
 - Added adaptive multi-scale embedding module
 - Introduced hardware acceleration helpers


### PR DESCRIPTION
## Summary
- make padding deterministic and track metadata so reconstructed data matches original
- quantize latent vectors to 16-bit precision and store metadata in compressed stream
- document neural compression precision fix in changelog

## Testing
- `python -m py_compile qch/optimized_neural_compression.py`
- `python - <<'PY'
from qch.optimized_neural_compression import OptimizedNeuralCompressor
comp = OptimizedNeuralCompressor(chunk_size=1024)
sample = b'Test data for precision.' * 10
compressed = comp.compress(sample)  # allow fallback
recovered = comp.decompress(compressed)
print('match', recovered == sample)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a202ffe368832cb827f12de404f97d