### PR TITLE
Connect CNN analysis to adaptive embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2025-08-18
+- Connected CNN-based region analysis with adaptive embedding planning and region-specific schemes
+- Added safety-aware capacity planning and region embedding helpers
+
 ## 2025-08-17
 - Improved neural compression precision with deterministic padding and 16-bit quantization
 - Added neural compression module and CLI integration

--- a/qch/adaptive_embedding_optimized.py
+++ b/qch/adaptive_embedding_optimized.py
@@ -4,6 +4,7 @@ import numpy as np
 from PIL import Image
 import cv2
 from typing import List, Tuple, Dict, Optional
+import math
 import time
 from dataclasses import dataclass
 
@@ -178,9 +179,8 @@ class OptimizedAdaptiveEmbedder:
                     torch.from_numpy(patch).permute(2, 0, 1).float() / 255.0
                     for patch in batch_patches
                 ]).to(self.device)
-                capacity_logits, safety_scores = self.neural_analyzer(batch_tensor)
-                capacity_probs = torch.softmax(capacity_logits, dim=1)
-                capacity_scores = (capacity_probs[:, 1] + 2 * capacity_probs[:, 2]) / 2
+                capacity_probs, safety_scores = self.neural_analyzer(batch_tensor)
+                capacity_scores = (capacity_probs[:, 1] + 2 * capacity_probs[:, 2]) / 3
                 for j, (x, y) in enumerate(batch_positions):
                     capacity_score = capacity_scores[j].cpu().item()
                     safety_score = safety_scores[j].cpu().item()
@@ -193,34 +193,69 @@ class OptimizedAdaptiveEmbedder:
             'analysis_method': 'neural_network',
         }
 
-    def create_embedding_plan(self, capacity_map: np.ndarray, data_size: int) -> Dict[str, any]:
+    def create_embedding_plan(
+        self,
+        capacity_map: np.ndarray,
+        safety_map: np.ndarray,
+        data_size: int,
+        scheme: str,
+    ) -> Dict[str, any]:
         h, w = capacity_map.shape
+        region_sizes = {
+            'lsb': 16,
+            'pvd': 20,
+            'matrix': 24,
+            'interp': 18,
+        }
+        region_size = region_sizes.get(scheme, 16)
         regions = []
-        block_size = 16
-        for y in range(0, h - block_size + 1, block_size):
-            for x in range(0, w - block_size + 1, block_size):
-                region_capacity = np.mean(capacity_map[y:y + block_size, x:x + block_size])
-                regions.append({'x': x, 'y': y, 'width': block_size, 'height': block_size,
-                                'capacity': region_capacity, 'priority': region_capacity})
+        for y in range(0, h - region_size + 1, region_size):
+            for x in range(0, w - region_size + 1, region_size):
+                region_capacity = np.mean(capacity_map[y:y + region_size, x:x + region_size])
+                region_safety = np.mean(safety_map[y:y + region_size, x:x + region_size])
+                if scheme == 'lsb':
+                    bpp = min(3, max(1, int(region_capacity * 3)))
+                elif scheme == 'pvd':
+                    bpp = max(1, int(region_capacity * 4))
+                elif scheme == 'matrix':
+                    bpp = 3 if region_capacity > 0.5 else 2
+                else:
+                    bpp = max(1, int(region_capacity * 2))
+                pixels = region_size * region_size
+                if scheme == 'matrix':
+                    region_bits = (pixels // 7) * 3
+                else:
+                    region_bits = pixels * bpp
+                region_bits = int(region_bits * region_safety)
+                regions.append(
+                    {
+                        'x': x,
+                        'y': y,
+                        'width': region_size,
+                        'height': region_size,
+                        'capacity_score': region_capacity,
+                        'safety_score': region_safety,
+                        'estimated_bits': region_bits,
+                        'bpp': bpp,
+                        'priority': region_capacity * region_safety,
+                    }
+                )
         regions.sort(key=lambda r: r['priority'], reverse=True)
-        total_capacity = sum(r['capacity'] for r in regions)
         bits_needed = data_size * 8
-        if total_capacity == 0:
-            raise ValueError("No suitable regions found for embedding")
         allocated_bits = 0
         for region in regions:
             if allocated_bits >= bits_needed:
                 region['bits_to_embed'] = 0
             else:
-                region_bits = int((region['capacity'] / total_capacity) * bits_needed)
-                region_bits = min(region_bits, bits_needed - allocated_bits)
-                region['bits_to_embed'] = region_bits
-                allocated_bits += region_bits
+                available_bits = min(region['estimated_bits'], bits_needed - allocated_bits)
+                region['bits_to_embed'] = available_bits
+                allocated_bits += available_bits
         return {
             'regions': regions,
-            'total_bits': bits_needed,
-            'allocated_bits': allocated_bits,
+            'total_bits_needed': bits_needed,
+            'total_bits_allocated': allocated_bits,
             'efficiency': allocated_bits / bits_needed if bits_needed > 0 else 0,
+            'estimated_capacity': sum(r['estimated_bits'] for r in regions),
         }
 
     def adaptive_embed(self, img: Image.Image, data: bytes, scheme: str, cfg, seed: bytes, logger) -> Image.Image:
@@ -230,17 +265,21 @@ class OptimizedAdaptiveEmbedder:
         else:
             analysis = self.analyze_image_fast(img)
         analysis_time = time.time() - start_time
-        logger.info(f"[ADAPTIVE] Image analysis completed in {analysis_time:.2f}s using {analysis['analysis_method']}")
-        logger.info(f"[ADAPTIVE] Estimated capacity: {analysis['total_capacity']} bits")
-        plan = self.create_embedding_plan(analysis['capacity_map'], len(data))
         logger.info(
-            f"[ADAPTIVE] Embedding plan: {plan['allocated_bits']}/{plan['total_bits']} bits (efficiency: {plan['efficiency']:.1%})"
+            f"[ADAPTIVE] Image analysis completed in {analysis_time:.2f}s using {analysis['analysis_method']}"
         )
-        from ..utils import bytes_to_bits
-        bits = bytes_to_bits(data)
-        if plan['allocated_bits'] < len(bits):
-            logger.warning(f"[ADAPTIVE] Insufficient capacity: need {len(bits)}, have {plan['allocated_bits']}")
+        logger.info(f"[ADAPTIVE] Estimated capacity: {analysis['total_capacity']} bits")
+        plan = self.create_embedding_plan(
+            analysis['capacity_map'], analysis['safety_map'], len(data), scheme
+        )
+        logger.info(
+            f"[ADAPTIVE] Plan: {plan['total_bits_allocated']}/{plan['total_bits_needed']} bits (efficiency: {plan['efficiency']:.1%})"
+        )
+        if plan['efficiency'] < 0.8:
+            logger.warning("[ADAPTIVE] Insufficient capacity, falling back to standard embedding")
             return self._fallback_embed(img, data, scheme, cfg, seed, logger)
+        from .utils import bytes_to_bits
+        bits = bytes_to_bits(data)
         img_np = np.array(img)
         modified_img = img_np.copy()
         bit_idx = 0
@@ -251,8 +290,16 @@ class OptimizedAdaptiveEmbedder:
             end_idx = min(bit_idx + region['bits_to_embed'], len(bits))
             region_bits = bits[bit_idx:end_idx]
             if len(region_bits) > 0:
-                success = self._embed_in_region(
-                    modified_img, region['x'], region['y'], region['width'], region['height'], region_bits, scheme
+                success = self._embed_in_region_adaptive(
+                    modified_img,
+                    region['x'],
+                    region['y'],
+                    region['width'],
+                    region['height'],
+                    region_bits,
+                    scheme,
+                    region['bpp'],
+                    seed,
                 )
                 if success:
                     bit_idx = end_idx
@@ -267,37 +314,197 @@ class OptimizedAdaptiveEmbedder:
         )
         return Image.fromarray(modified_img)
 
-    def _embed_in_region(self, img_np: np.ndarray, x: int, y: int, width: int, height: int, bits: List[int], scheme: str) -> bool:
+    def _embed_in_region_adaptive(
+        self,
+        img_np: np.ndarray,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        bits: List[int],
+        scheme: str,
+        bpp: int,
+        seed: bytes,
+    ) -> bool:
         try:
-            bit_idx = 0
-            for dy in range(height):
-                for dx in range(width):
-                    if bit_idx >= len(bits):
-                        return True
-                    px, py = x + dx, y + dy
-                    if 0 <= px < img_np.shape[1] and 0 <= py < img_np.shape[0]:
-                        img_np[py, px, 2] = (img_np[py, px, 2] & 0xFE) | (bits[bit_idx] & 1)
-                        bit_idx += 1
-            return True
+            if scheme == 'lsb':
+                return self._embed_lsb_region(img_np, x, y, width, height, bits, bpp, seed)
+            elif scheme == 'pvd':
+                return self._embed_pvd_region(img_np, x, y, width, height, bits, seed)
+            elif scheme == 'matrix':
+                return self._embed_matrix_region(img_np, x, y, width, height, bits, seed)
+            elif scheme == 'interp':
+                return self._embed_interp_region(img_np, x, y, width, height, bits, seed)
+            else:
+                return self._embed_lsb_region(img_np, x, y, width, height, bits, 1, seed)
         except Exception:
             return False
 
+    def _embed_lsb_region(
+        self,
+        img_np: np.ndarray,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        bits: List[int],
+        bpp: int,
+        seed: bytes,
+    ) -> bool:
+        from .utils import prng
+        positions = []
+        for dy in range(height):
+            for dx in range(width):
+                px, py = x + dx, y + dy
+                if 0 <= px < img_np.shape[1] and 0 <= py < img_np.shape[0]:
+                    positions.append((py, px, 2))
+        r = prng(seed + f"{x}_{y}".encode())
+        r.shuffle(positions)
+        bit_idx = 0
+        for py, px, channel in positions:
+            for bit_pos in range(bpp):
+                if bit_idx >= len(bits):
+                    return True
+                mask = ~(1 << bit_pos) & 0xFF
+                img_np[py, px, channel] = (img_np[py, px, channel] & mask) | ((bits[bit_idx] & 1) << bit_pos)
+                bit_idx += 1
+        return True
+
+    def _embed_pvd_region(
+        self,
+        img_np: np.ndarray,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        bits: List[int],
+        seed: bytes,
+    ) -> bool:
+        from .schemes.pvd import PVD_RANGES
+        from .utils import prng
+        pairs = []
+        for dy in range(height):
+            for dx in range(0, width - 1, 2):
+                px1, py1 = x + dx, y + dy
+                px2, py2 = x + dx + 1, y + dy
+                if 0 <= px2 < img_np.shape[1] and 0 <= py2 < img_np.shape[0]:
+                    pairs.append(((py1, px1, 2), (py2, px2, 2)))
+        r = prng(seed + f"{x}_{y}".encode())
+        r.shuffle(pairs)
+        bit_idx = 0
+        for (py1, px1, c1), (py2, px2, c2) in pairs:
+            if bit_idx >= len(bits):
+                break
+            p1 = img_np[py1, px1, c1]
+            p2 = img_np[py2, px2, c2]
+            d = abs(int(p1) - int(p2))
+            for a, b in PVD_RANGES:
+                if a <= d <= b:
+                    w = b - a + 1
+                    t = int(math.floor(math.log2(w))) if w > 1 else 0
+                    if t <= 0:
+                        break
+                    val = 0
+                    for _ in range(min(t, len(bits) - bit_idx)):
+                        val = (val << 1) | (bits[bit_idx] & 1)
+                        bit_idx += 1
+                    new_d = a + val
+                    if new_d > b:
+                        new_d = b
+                    if p1 >= p2:
+                        delta = new_d - d
+                        p1_new = max(0, min(255, p1 + delta // 2))
+                        p2_new = max(0, min(255, p2 - delta // 2))
+                    else:
+                        delta = new_d - d
+                        p2_new = max(0, min(255, p2 + delta // 2))
+                        p1_new = max(0, min(255, p1 - delta // 2))
+                    img_np[py1, px1, c1] = p1_new
+                    img_np[py2, px2, c2] = p2_new
+                    break
+        return True
+
+    def _embed_matrix_region(
+        self,
+        img_np: np.ndarray,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        bits: List[int],
+        seed: bytes,
+    ) -> bool:
+        from .schemes.matrix import hamming_syndrome
+        from .utils import prng
+        positions = []
+        for dy in range(height):
+            for dx in range(width):
+                px, py = x + dx, y + dy
+                if 0 <= px < img_np.shape[1] and 0 <= py < img_np.shape[0]:
+                    positions.append((py, px, 2))
+        r = prng(seed + f"{x}_{y}".encode())
+        r.shuffle(positions)
+        groups = [positions[i:i + 7] for i in range(0, len(positions), 7)]
+        bit_idx = 0
+        for group in groups:
+            if len(group) < 7 or bit_idx >= len(bits):
+                break
+            current_bits = [img_np[py, px, c] & 1 for py, px, c in group]
+            m0 = bits[bit_idx] if bit_idx < len(bits) else 0
+            m1 = bits[bit_idx + 1] if bit_idx + 1 < len(bits) else 0
+            m2 = bits[bit_idx + 2] if bit_idx + 2 < len(bits) else 0
+            bit_idx += 3
+            syndrome = hamming_syndrome(current_bits)
+            e2 = m0 ^ syndrome[0]
+            e1 = m1 ^ syndrome[1]
+            e0 = m2 ^ syndrome[2]
+            error_pos = (e2 << 2) | (e1 << 1) | e0
+            if error_pos != 0 and error_pos - 1 < len(group):
+                py, px, c = group[error_pos - 1]
+                img_np[py, px, c] ^= 1
+        return True
+
+    def _embed_interp_region(
+        self,
+        img_np: np.ndarray,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        bits: List[int],
+        seed: bytes,
+    ) -> bool:
+        from .utils import prng
+        positions = []
+        for dy in range(height):
+            for dx in range(width):
+                px, py = x + dx, y + dy
+                if 0 <= px < img_np.shape[1] and 0 <= py < img_np.shape[0] and ((px & 1) or (py & 1)):
+                    positions.append((py, px, 2))
+        r = prng(seed + f"{x}_{y}".encode())
+        r.shuffle(positions)
+        for i, (py, px, c) in enumerate(positions):
+            if i >= len(bits):
+                break
+            img_np[py, px, c] = (img_np[py, px, c] & 0xFE) | (bits[i] & 1)
+        return True
+
     def _fallback_embed(self, img: Image.Image, data: bytes, scheme: str, cfg, seed: bytes, logger) -> Image.Image:
         logger.info("[ADAPTIVE] Falling back to standard embedding")
-        from ..stego import embed_one
-        from ..utils import bytes_to_bits
+        from .stego import embed_one
+        from .utils import bytes_to_bits
         bits = bytes_to_bits(data)
         if scheme == "lsb":
-            from ..schemes.lsb import embed_lsb_scatter
+            from .schemes.lsb import embed_lsb_scatter
             return embed_lsb_scatter(img, bits, cfg, seed, logger)
         elif scheme == "pvd":
-            from ..schemes.pvd import pvd_embed
+            from .schemes.pvd import pvd_embed
             return pvd_embed(img, bits, cfg, seed, logger)
         elif scheme == "matrix":
-            from ..schemes.matrix import matrix_embed
+            from .schemes.matrix import matrix_embed
             return matrix_embed(img, bits, cfg, seed, logger)
         elif scheme == "interp":
-            from ..schemes.interp import interp_embed
+            from .schemes.interp import interp_embed
             return interp_embed(img, bits, cfg, seed, logger)
         else:
             raise ValueError(f"Unknown embedding scheme: {scheme}")


### PR DESCRIPTION
## Summary
- connect CNN-based capacity and safety analysis to region-wise embedding plan
- add scheme-specific region embedding helpers and safety-aware planning
- document changes

## Testing
- `python -m py_compile qch/adaptive_embedding_optimized.py`
- `python - <<'PY'
from qch.adaptive_embedding_optimized import benchmark_adaptive_embedding
benchmark_adaptive_embedding()
PY`
- `python - <<'PY'
import logging, numpy as np
from PIL import Image
from qch.adaptive_embedding_optimized import create_adaptive_embedder
logger = logging.getLogger('test'); logger.setLevel(logging.INFO); logger.addHandler(logging.StreamHandler())
embedder = create_adaptive_embedder(use_neural=False)
img = Image.fromarray(np.random.randint(0,256,(128,128,3),dtype=np.uint8))
embedder.adaptive_embed(img, b'hello world', 'lsb', None, b'seed', logger)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a3127bd144832cb9f48178e847e6db