### PR TITLE
feat: add robust quantum crypto fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2025-08-18
 - Connected CNN-based region analysis with adaptive embedding planning and region-specific schemes
 - Added safety-aware capacity planning and region embedding helpers
+- Enhanced quantum cryptography module with robust fallbacks and dependency handling
 
 ## 2025-08-17
 - Improved neural compression precision with deterministic padding and 16-bit quantization


### PR DESCRIPTION
## Summary
- replace quantum crypto integration with robust implementation using secure classical fallbacks when liboqs is unavailable
- add SafeQuantumQCH wrapper and backward-compatible aliases
- document quantum crypto changes in changelog

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a322eea074832c921700de9e9b55b4